### PR TITLE
zeebe dependencies: use updated name and version, old ones were removed

### DIFF
--- a/helm/ph-ee-engine/requirements.yaml
+++ b/helm/ph-ee-engine/requirements.yaml
@@ -1,10 +1,10 @@
 dependencies:
-- name: zeebe-cluster
+- name: zeebe-cluster-helm
   repository: https://helm.camunda.io
-  version: 0.0.122
-- name: zeebe-operate
+  version: 1.0.0
+- name: zeebe-operate-helm
   repository: https://helm.camunda.io
-  version: 0.0.28
+  version: 1.0.0
   condition: "zeebe-operate.enabled"
 - name: elasticsearch
   repository: http://helm.elastic.co 


### PR DESCRIPTION
I believe the deps referred to in requirements.yaml are have been removed upstream and perhaps renamed, as the version / name doesn't exist
I think they re-released the packages with `-helm` at the end, at version 1.0.0
I'm new to this project, and haven't made it very far, please ensure I've pulled in the right thing