### PR TITLE
FIXES PHEE-181 : Removed the static namespace in mojaloop service

### DIFF
--- a/helm/ph-ee-engine/templates/connector-mojaloop-java.yaml
+++ b/helm/ph-ee-engine/templates/connector-mojaloop-java.yaml
@@ -55,7 +55,6 @@ metadata:
   labels:
     app: ph-ee-connector-mojaloop-java
   name: ph-ee-connector-mojaloop-java
-  namespace: default
 spec:
   ports:
     - name: port


### PR DESCRIPTION
## Description

* Fixes https://fynarfin.atlassian.net/browse/PHEE-181?atlOrigin=eyJpIjoiM2U3ODEwYjMxNTZiNDA2YWI4YWRkM2U5Mjk5OWNlMmUiLCJwIjoiamlyYS1zbGFjay1pbnQifQ

## Checklist

Please make sure these boxes are checked before submitting your pull request - thanks!

- [x] Design related bullet points or design document link related to this PR added in the description above. 

- [x] Updated corresponding Postman Collection or Api documentation for the changes in this PR.

- [x] Create/update unit or integration tests for verifying the changes made.

- [x] Add required Swagger annotation and update API documentation with details of any API changes if applicable

- [x] Followed the naming conventions as given in https://docs.google.com/document/d/1Q4vaMSzrTxxh9TS0RILuNkSkYCxotuYk1Xe0CMIkkCU/edit?usp=sharing
