### PR TITLE
remove unused zeebe-cluster-helm

### DIFF
--- a/helm/g2p-sandbox/values.yaml
+++ b/helm/g2p-sandbox/values.yaml
@@ -22,33 +22,6 @@ ph-ee-engine:
     tenants: "rhino,gorilla"
     DFSPIDS: "gorilla,lion"
 
-  zeebe-cluster-helm:
-    enabled: false
-    global:
-      elasticsearch:
-        host: "ph-ee-elasticsearch"
-    image:
-      repository: camunda/zeebe
-      tag: 1.1.0
-    clusterSize: "1"
-    partitionCount: "1"
-    replicationFactor: "1"
-    JavaOpts: "-Xms8g -Xmx8g -XX:+UseParallelGC -XX:MinHeapFreeRatio=5 -XX:MaxHeapFreeRatio=10 -XX:MaxRAMPercentage=25.0 -XX:GCTimeRatio=4 -XX:AdaptiveSizePolicyWeight=90 -XX:+PrintFlagsFinal"
-
-    elasticsearch:
-      enabled: false
-    kibana:
-      enabled: true
-
-    extraInitContainers: |
-      - name: init-ph-ee-kafka-exporter
-        image: busybox:1.28
-        command: ['/bin/sh', '-c']
-        args: ['wget -O /exporters/ph-ee-kafka-exporter.jar "https://paymenthub-ee-dev.s3.us-east-2.amazonaws.com/jars/exporter-1.0.0-SNAPSHOT.jar"; ls -al /exporters/']
-        volumeMounts:
-        - name: exporters
-          mountPath: /exporters/
-
   zeebe-operate-helm:
     enabled: true
     image:


### PR DESCRIPTION
## Description

* this is to fix a bug introduced as part of zeebe upgrade 
* the zeebe-cluster-helm is unused in the chart and it still exists in the code

 _(Ignore if these details are present on the associated JIRA ticket)_

## Checklist

Please make sure these boxes are checked before submitting your pull request - thanks!

- [ ] Design related bullet points or design document link related to this PR added in the description above. 

- [ ] Updated corresponding Postman Collection or Api documentation for the changes in this PR.

- [ ] Create/update unit or integration tests for verifying the changes made.

- [ ] Add required Swagger annotation and update API documentation with details of any API changes if applicable

- [ ] Followed the naming conventions as given in https://docs.google.com/document/d/1Q4vaMSzrTxxh9TS0RILuNkSkYCxotuYk1Xe0CMIkkCU/edit?usp=sharing