### PR TITLE
PHEE-425 Not able to disable redis config for channel-connector

### DIFF
--- a/helm/ph-ee-engine/connector-channel/templates/deployment.yaml
+++ b/helm/ph-ee-engine/connector-channel/templates/deployment.yaml
@@ -84,6 +84,7 @@ spec:
               value: "{{ .Values.tenantSecondary.clientSecret }}"
             - name: "CHANNEL_TENANTSECONDARY_TENANT"
               value: "{{ .Values.tenantSecondary.tenant }}"
+{{- if .Values.redis.idempotency.enabled }}
             - name: "redis_idempotency_enabled"
               value: "{{ .Values.redis.idempotency.enabled }}"
             - name: "redis_host"
@@ -99,6 +100,7 @@ spec:
                 secretKeyRef:
                   name: "{{ .Release.Name }}-redis" 
                   key: "redis-password"
+{{end}}
             - name: "server_ssl_key-password"
               value: "{{ .Values.server.ssl.keyPassword }}" 
             - name: "server_ssl_key-store-password"


### PR DESCRIPTION
## Description

[PHEE-425 Not able to disable redis config for channel-connector](https://fynarfin.atlassian.net/browse/PHEE-425?atlOrigin=eyJpIjoiYjE4ZWI0YzI4NDNiNDBhZmFiNzk1ZGE5NzA1ODk2ZWYiLCJwIjoiamlyYS1zbGFjay1pbnQifQ)
## Checklist

Please make sure these boxes are checked before submitting your pull request - thanks!

- [x] Design related bullet points or design document link related to this PR added in the description above. 

- [ ] Updated corresponding Postman Collection or Api documentation for the changes in this PR.

- [ ] Create/update unit or integration tests for verifying the changes made.

- [ ] Add required Swagger annotation and update API documentation with details of any API changes if applicable

- [ ] Followed the naming conventions as given in https://docs.google.com/document/d/1Q4vaMSzrTxxh9TS0RILuNkSkYCxotuYk1Xe0CMIkkCU/edit?usp=sharing