### PR TITLE
GOV-287: Migrated channel ingress to kong

### DIFF
--- a/helm/g2p-sandbox/values.yaml
+++ b/helm/g2p-sandbox/values.yaml
@@ -226,11 +226,11 @@ ph-ee-engine:
       ssl:
         keyPassword: "<replace-with-password>"
         keyStorePassword: "<replace-with-password>"
+    service:
+      annotations:
+        konghq.com/protocol: "https"
     ingress:
       enabled: false
-      annotations: 
-        kubernetes.io/ingress.class: nginx
-        nginx.ingress.kubernetes.io/backend-protocol: "HTTPS" 
       tls:
         - secretName: sandbox-secret
       hosts:

--- a/helm/g2p-sandbox/values.yaml
+++ b/helm/g2p-sandbox/values.yaml
@@ -226,9 +226,6 @@ ph-ee-engine:
       ssl:
         keyPassword: "<replace-with-password>"
         keyStorePassword: "<replace-with-password>"
-    service:
-      annotations:
-        konghq.com/protocol: "https"
     ingress:
       enabled: false
       tls:

--- a/helm/ph-ee-engine/connector-channel/templates/service.yaml
+++ b/helm/ph-ee-engine/connector-channel/templates/service.yaml
@@ -12,7 +12,7 @@ metadata:
 spec:
   ports:
     - name: port
-      port: 80
+      port: 8443
       protocol: TCP
       targetPort: 8443
     - name: http

--- a/helm/ph-ee-engine/connector-channel/templates/service.yaml
+++ b/helm/ph-ee-engine/connector-channel/templates/service.yaml
@@ -5,6 +5,10 @@ metadata:
   labels:
     app: ph-ee-connector-channel
   name: ph-ee-connector-channel
+{{- with .Values.service.annotations }}
+  annotations:
+{{ toYaml . | indent 4 }}
+{{- end }}
 spec:
   ports:
     - name: port

--- a/helm/ph-ee-engine/connector-channel/templates/service.yaml
+++ b/helm/ph-ee-engine/connector-channel/templates/service.yaml
@@ -12,7 +12,7 @@ metadata:
 spec:
   ports:
     - name: port
-      port: 8443
+      port: 80
       protocol: TCP
       targetPort: 8443
     - name: http

--- a/helm/ph-ee-engine/connector-channel/values.yaml
+++ b/helm/ph-ee-engine/connector-channel/values.yaml
@@ -1,5 +1,6 @@
 service:
   apiversion: "v1"
+  annotations: {}
 
 secret:
   apiversion: "v1"

--- a/helm/ph-ee-engine/values.yaml
+++ b/helm/ph-ee-engine/values.yaml
@@ -271,7 +271,9 @@ channel:
       cpu: "500m"
     requests:
       memory: "512M"
-      cpu: "100m"       
+      cpu: "100m"
+  service:
+    annotations: {}
 # Enabling this will publicly expose your channel instance.
 # Only enable this if you have security enabled on your cluster    
   ingress:


### PR DESCRIPTION
## Description

* Parameterised channel-connector service.yaml for annotation support.
* Migrated the channel ingress to kong.

[GOV-287](https://mifosforge.jira.com/browse/GOV-287)
Linked PR: https://github.com/openMF/ph-ee-env-labs/pull/174

## Checklist

Please make sure these boxes are checked before submitting your pull request - thanks!

- [x] Design related bullet points or design document link related to this PR added in the description above. 

- [x] Updated corresponding Postman Collection or Api documentation for the changes in this PR.

- [x] Create/update unit or integration tests for verifying the changes made.

- [x] Add required Swagger annotation and update API documentation with details of any API changes if applicable

- [x] Followed the naming conventions as given in https://docs.google.com/document/d/1Q4vaMSzrTxxh9TS0RILuNkSkYCxotuYk1Xe0CMIkkCU/edit?usp=sharing

[GOV-287]: https://mifosforge.jira.com/browse/GOV-287?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ