### PR TITLE
PHEE:457: Changed the mock-payment-schema port to 8080 form 80

### DIFF
--- a/helm/ph-ee-engine/connector-mock-payment-schema/templates/service.yaml
+++ b/helm/ph-ee-engine/connector-mock-payment-schema/templates/service.yaml
@@ -8,7 +8,7 @@ metadata:
 spec:
   ports:
     - name: port
-      port: 80
+      port: 8080
       protocol: TCP
       targetPort: 8080
   selector:


### PR DESCRIPTION
## Description

* Mock-payment-schema service port changed from 80 to 8080.

## Checklist

Please make sure these boxes are checked before submitting your pull request - thanks!

- [x] Design related bullet points or design document link related to this PR added in the description above. 

- [x] Updated corresponding Postman Collection or Api documentation for the changes in this PR.

- [x] Create/update unit or integration tests for verifying the changes made.

- [x] Add required Swagger annotation and update API documentation with details of any API changes if applicable

- [x] Followed the naming conventions as given in https://docs.google.com/document/d/1Q4vaMSzrTxxh9TS0RILuNkSkYCxotuYk1Xe0CMIkkCU/edit?usp=sharing