### PR TITLE
[phee-477]FIX: using latest image instead of jira-tag image

### DIFF
--- a/.circleci/docker-image-availability-check-and-upgrade.yml
+++ b/.circleci/docker-image-availability-check-and-upgrade.yml
@@ -59,7 +59,6 @@ commands:
             function get_services_from_file() {
                 file=$1
                 while IFS= read -r line || [ -n "$line" ]; do
-                  echo "Processing line: $line"
                   generate_values_to_override $line
                 done < "$file"
             }
@@ -67,14 +66,14 @@ commands:
             function generate_values_to_override() {
               PREFIX="docker.io/"
               if [ "$CIRCLE_BRANCH" != "master" ] && check_for_image_tag ${2#"$PREFIX"} ${JIRA_STORY}; then
-                  echo "$1=$2:$JIRA_STORY"
+                  echo "image: < $1=$2:$JIRA_STORY >"
                   VALUES_TO_OVERRIDE+=$(echo "$1=$2:$JIRA_STORY"),
               else
+                  echo "image: < $1=$2:latest >"
                   VALUES_TO_OVERRIDE+=$(echo "$1=$2:latest"),
               fi
             }
             function check_for_image_tag(){
-              echo "checking for service with image tag $1 $2"
               curl --silent -f --head -lL https://hub.docker.com/v2/repositories/$1/tags/$2/ > /dev/null
             }
             if [ "$CIRCLE_BRANCH" != "master" ]; then

--- a/.circleci/docker-image-availability-check-and-upgrade.yml
+++ b/.circleci/docker-image-availability-check-and-upgrade.yml
@@ -66,7 +66,7 @@ commands:
             
             function generate_values_to_override() {
               PREFIX="docker.io/"
-              if "$CIRCLE_BRANCH" != "master" && check_for_image_tag ${2#"$PREFIX"} ${JIRA_STORY}; then
+              if [ "$CIRCLE_BRANCH" != "master" ] && check_for_image_tag ${2#"$PREFIX"} ${JIRA_STORY}; then
                   echo "$1=$2:$JIRA_STORY"
                   VALUES_TO_OVERRIDE+=$(echo "$1=$2:$JIRA_STORY"),
               else


### PR DESCRIPTION
## Description

[PHEE-477 Create an orb that fetches the docker images and do helm upgrade](https://fynarfin.atlassian.net/browse/PHEE-477?atlOrigin=eyJpIjoiNDU5MjQzNzc4MGJhNDA1YmFhMmQ0MGI4OGU2ZmEyNDgiLCJwIjoiamlyYS1zbGFjay1pbnQifQ)

## Checklist

Please make sure these boxes are checked before submitting your pull request - thanks!
- [x] Followed the PR title naming convention mentioned above.

- [x] Design related bullet points or design document link related to this PR added in the description above. 

- [ ] Updated corresponding Postman Collection or Api documentation for the changes in this PR.

- [ ] Created/updated unit or integration tests for verifying the changes made.

- [ ] Added required Swagger annotation and update API documentation with details of any API changes if applicable

- [ ] Followed the naming conventions as given in https://docs.google.com/document/d/1Q4vaMSzrTxxh9TS0RILuNkSkYCxotuYk1Xe0CMIkkCU/edit?usp=sharing
