### PR TITLE
PHEE-498 Add ops app variable api in postman collection

### DIFF
--- a/PostmanCollections/Payment Hub.json
+++ b/PostmanCollections/Payment Hub.json
@@ -1766,6 +1766,98 @@
           "response": []
         },
         {
+          "name": "Variables",
+          "request": {
+            "auth": {
+              "type": "noauth"
+            },
+            "method": "GET",
+            "header": [
+              {
+                "key": "User-Agent",
+                "value": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10.15; rv:90.0) Gecko/20100101 Firefox/90.0",
+                "disabled": true
+              },
+              {
+                "key": "Accept",
+                "value": "application/json, text/plain, */*",
+                "disabled": true
+              },
+              {
+                "key": "Accept-Language",
+                "value": "en-US,en;q=0.5",
+                "disabled": true
+              },
+              {
+                "key": "Platform-TenantId",
+                "value": "{{TenantName}}"
+              },
+              {
+                "key": "Authorization",
+                "value": "Bearer eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJhdWQiOlsiaWRlbnRpdHktcHJvdmlkZXIiLCJvYWYiXSwidXNlcl9uYW1lIjoibWlmb3MiLCJzY29wZSI6WyJpZGVudGl0eSJdLCJleHAiOjE2NDI2NzA0MTcsImF1dGhvcml0aWVzIjpbIlJFRlVORCIsIkFMTF9GVU5DVElPTlMiXSwianRpIjoiQStsajFsRVNsWW9YMU9uNjdyTlNRbFhHY05VPSIsImNsaWVudF9pZCI6ImNsaWVudCJ9.flZD_GlQJ2w8P_cU0DC2hojJLUA9WS_Bc3yy9X-1v8hR1xhJZjdHUKfBl-TqNdwPnWHEvuKNdsGSEzNCP8CYR71n3J33gzEpcKVZ0P7d2bOOLX6EgtSjDdjSLU_IGRxmOZEGES9p-UPAARbj24vIM3kugG6jBbVTJ08DksnLRXP0MdWjAmW6JNq0Y2VAJq_0LSCdab5XZT-vQsRL5PdrKvPT1w28jDFklWCrft6G-6SQbqkJPGR_oQPwYBmaZOx5ateE6JDMZN5CVmejExRVPYgE-tMxXRh7GZFTDaSW1DiMzNriBeDSu3NUkuwOCC4B4Z-XmzQJw36uE6pvqGT-Pg",
+                "disabled": true
+              },
+              {
+                "key": "Origin",
+                "value": "http://localhost:4200",
+                "disabled": true
+              },
+              {
+                "key": "Connection",
+                "value": "keep-alive",
+                "disabled": true
+              },
+              {
+                "key": "Referer",
+                "value": "http://localhost:4200/",
+                "disabled": true
+              }
+            ],
+            "url": {
+              "raw": "{{OperationsHostName}}/api/v1/variables/21037e77-7227-4757-8e45-5c356f369b11",
+              "host": [
+                "{{OperationsHostName}}"
+              ],
+              "path": [
+                "api",
+                "v1",
+                "variables",
+                "21037e77-7227-4757-8e45-5c356f369b11"
+              ],
+              "query": [
+                {
+                  "key": "direction",
+                  "value": "OUTGOING",
+                  "description": "INCOMING or OUTGOING direction",
+                  "disabled": true
+                },
+                {
+                  "key": "status",
+                  "value": "{{status}}",
+                  "description": "Transaction Status. Values can be COMPLETED, FAILED, IN_PROGRESS and ALL. By default set to ALL.",
+                  "disabled": true
+                },
+                {
+                  "key": "size",
+                  "value": "1",
+                  "disabled": true
+                },
+                {
+                  "key": "page",
+                  "value": "0",
+                  "disabled": true
+                },
+                {
+                  "key": "clientCorrelationId",
+                  "value": "123456789",
+                  "disabled": true
+                }
+              ]
+            }
+          },
+          "response": []
+        },
+        {
           "name": "Get Transaction Request",
           "request": {
             "auth": {


### PR DESCRIPTION
Add ops app variable api in postman collection
[PHEE-498 Update Ops app variable API to check transaction ID in transactionRequest](https://fynarfin.atlassian.net/browse/PHEE-498?atlOrigin=eyJpIjoiNTBhYmRjNzU5YTk2NGJhMWIzMTA4NTQzY2FkYmFjNmIiLCJwIjoiamlyYS1zbGFjay1pbnQifQ)

## Checklist

Please make sure these boxes are checked before submitting your pull request - thanks!
- [ ] Followed the PR title naming convention mentioned above.

- [ ] Design related bullet points or design document link related to this PR added in the description above. 

- [ ] Updated corresponding Postman Collection or Api documentation for the changes in this PR.

- [ ] Created/updated unit or integration tests for verifying the changes made.

- [ ] Added required Swagger annotation and update API documentation with details of any API changes if applicable

- [ ] Followed the naming conventions as given in https://docs.google.com/document/d/1Q4vaMSzrTxxh9TS0RILuNkSkYCxotuYk1Xe0CMIkkCU/edit?usp=sharing
