### PR TITLE
[PHEE-506] Wrong chart is used in g2p-security-chart

### DIFF
--- a/helm/g2p-sandbox-security/requirements.yaml
+++ b/helm/g2p-sandbox-security/requirements.yaml
@@ -1,4 +1,0 @@
-dependencies:
-- name: ph-ee-engine
-  repository: https://fynarfin.io/images/ph-ee-engine-0.0.0-SNAPSHOT
-  version: 0.0.0-SNAPSHOT


### PR DESCRIPTION
## Description

[PHEE-506 Wrong chart is used in g2p-security-chart](https://fynarfin.atlassian.net/browse/PHEE-506?atlOrigin=eyJpIjoiMWY3NzJmYTI2Y2QxNGYwN2IyOWVjN2M3OGYxOWY3NDkiLCJwIjoiamlyYS1zbGFjay1pbnQifQ)

## Checklist

Please make sure these boxes are checked before submitting your pull request - thanks!
- [x] Followed the PR title naming convention mentioned above.

- [x] Design related bullet points or design document link related to this PR added in the description above. 

- [ ] Updated corresponding Postman Collection or Api documentation for the changes in this PR.

- [ ] Created/updated unit or integration tests for verifying the changes made.

- [ ] Added required Swagger annotation and update API documentation with details of any API changes if applicable

- [ ] Followed the naming conventions as given in https://docs.google.com/document/d/1Q4vaMSzrTxxh9TS0RILuNkSkYCxotuYk1Xe0CMIkkCU/edit?usp=sharing
