### PR TITLE
[PHEE-515] invalid bulk processor host name in service

### DIFF
--- a/helm/ph-ee-engine/connector-bulk/templates/service.yaml
+++ b/helm/ph-ee-engine/connector-bulk/templates/service.yaml
@@ -12,7 +12,7 @@ metadata:
 spec:
   ports:
     - name: port
-      port: 80
+      port: 8443
       protocol: TCP
       targetPort: 8443
   selector:


### PR DESCRIPTION
## Description

[PHEE-515 invalid bulk processor host name in service](https://fynarfin.atlassian.net/browse/PHEE-515?atlOrigin=eyJpIjoiZWQ1ZTZhYWViNTk5NGE0MGE4NTY5OThiNjVjOTQ4ZWMiLCJwIjoiamlyYS1zbGFjay1pbnQifQ)

## Checklist

Please make sure these boxes are checked before submitting your pull request - thanks!
- [x] Followed the PR title naming convention mentioned above.

- [x] Design related bullet points or design document link related to this PR added in the description above. 

- [ ] Updated corresponding Postman Collection or Api documentation for the changes in this PR.

- [ ] Created/updated unit or integration tests for verifying the changes made.

- [ ] Added required Swagger annotation and update API documentation with details of any API changes if applicable

- [ ] Followed the naming conventions as given in https://docs.google.com/document/d/1Q4vaMSzrTxxh9TS0RILuNkSkYCxotuYk1Xe0CMIkkCU/edit?usp=sharing
