### PR TITLE
[PHEE-520]Wrong chart is used in integration test repo

### DIFF
--- a/.circleci/docker-image-availability-check-and-upgrade.yml
+++ b/.circleci/docker-image-availability-check-and-upgrade.yml
@@ -120,8 +120,8 @@ commands:
             helm repo add "${ORB_PARAM_RELEASE_NAME}" "${ORB_PARAM_REPO}"
 
             helm repo update
-            echo "helm upgrade --install ${VALUES_TO_OVERRIDE} ${ORB_PARAM_RELEASE_NAME} ${ORB_PARAM_CHART} ${ORB_PARAM_NAMESPACE}"
-            helm upgrade --install ${VALUES_TO_OVERRIDE} ${ORB_PARAM_RELEASE_NAME} ${ORB_PARAM_CHART} ${ORB_PARAM_NAMESPACE}
+            echo "helm upgrade --install ${VALUES_TO_OVERRIDE} ${ORB_PARAM_RELEASE_NAME} ${CHART_URL} ${ORB_PARAM_NAMESPACE}"
+            helm upgrade --install ${VALUES_TO_OVERRIDE} ${ORB_PARAM_RELEASE_NAME} ${CHART_URL} ${ORB_PARAM_NAMESPACE}
 
 jobs:
   docker-image-availability-check-and-upgrade:


### PR DESCRIPTION
## Description

[PHEE-520 Wrong chart is used by orb in integration test repo](https://fynarfin.atlassian.net/browse/PHEE-520?atlOrigin=eyJpIjoiMWY2NzgxZGFmN2QzNDBlYTkxYjI0ZDYwM2FhNDlhMjIiLCJwIjoiamlyYS1zbGFjay1pbnQifQ)

## Checklist

Please make sure these boxes are checked before submitting your pull request - thanks!
- [x] Followed the PR title naming convention mentioned above.

- [x] Design related bullet points or design document link related to this PR added in the description above. 

- [ ] Updated corresponding Postman Collection or Api documentation for the changes in this PR.

- [ ] Created/updated unit or integration tests for verifying the changes made.

- [ ] Added required Swagger annotation and update API documentation with details of any API changes if applicable

- [ ] Followed the naming conventions as given in https://docs.google.com/document/d/1Q4vaMSzrTxxh9TS0RILuNkSkYCxotuYk1Xe0CMIkkCU/edit?usp=sharing
