### PR TITLE
[PHEE-667] Enable prometheus service monitor in chart and export data in metri…

### DIFF
--- a/helm/ph-ee-engine/values.yaml
+++ b/helm/ph-ee-engine/values.yaml
@@ -26,6 +26,7 @@ global:
   max_execution_threads: 50
   poll_interval: 10
 camunda-platform:
+
   connectors:
     enabled: false
   global:
@@ -37,6 +38,10 @@ camunda-platform:
       auth:
         enabled: false
 
+prometheusServiceMonitor:
+  ## @param prometheusServiceMonitor.enabled if true then a service monitor will be deployed, which allows an installed prometheus controller to scrape metrics from the deployed pods
+  enabled: false
+
   zeebe:
     enabled: true
     env:
@@ -44,6 +49,7 @@ camunda-platform:
       #      value: "false"
       - name: ZEEBE_BROKER_EXECUTION_METRICS_EXPORTER_ENABLED
         value: "true"
+      - name:
       - name: ZEEBE_BROKER_EXPORTERS_ELASTICSEARCH_CLASSNAME
         value: "hu.dpc.rt.kafkastreamer.exporter.NoOpExporter"
       - name: ZEEBE_BROKER_EXPORTERS_ELASTICSEARCH_JARPATH

--- a/helm/ph-ee-engine/values.yaml
+++ b/helm/ph-ee-engine/values.yaml
@@ -49,7 +49,6 @@ prometheusServiceMonitor:
       #      value: "false"
       - name: ZEEBE_BROKER_EXECUTION_METRICS_EXPORTER_ENABLED
         value: "true"
-      - name:
       - name: ZEEBE_BROKER_EXPORTERS_ELASTICSEARCH_CLASSNAME
         value: "hu.dpc.rt.kafkastreamer.exporter.NoOpExporter"
       - name: ZEEBE_BROKER_EXPORTERS_ELASTICSEARCH_JARPATH


### PR DESCRIPTION
## Description

[PHEE-667 Enable prometheus service monitor in chart and export data in metri…](https://fynarfin.atlassian.net/browse/PHEE-667?atlOrigin=eyJpIjoiNThmNDA0MzE3YWNiNGQyMDg5MDYzMjNhNmY2OTVkODUiLCJwIjoiamlyYS1zbGFjay1pbnQifQ)

## Checklist

Please make sure these boxes are checked before submitting your pull request - thanks!
- [ ] Followed the PR title naming convention mentioned above.

- [ ] Design related bullet points or design document link related to this PR added in the description above. 

- [ ] Updated corresponding Postman Collection or Api documentation for the changes in this PR.

- [ ] Created/updated unit or integration tests for verifying the changes made.

- [ ] Added required Swagger annotation and update API documentation with details of any API changes if applicable

- [ ] Followed the naming conventions as given in https://docs.google.com/document/d/1Q4vaMSzrTxxh9TS0RILuNkSkYCxotuYk1Xe0CMIkkCU/edit?usp=sharing
