### PR TITLE
SND-675 this changes allows turn on and off TLS connection with connector-bulk. 

### DIFF
--- a/helm/ph-ee-engine/connector-bulk/templates/deployment.yaml
+++ b/helm/ph-ee-engine/connector-bulk/templates/deployment.yaml
@@ -35,6 +35,12 @@ spec:
               memory: "{{ .Values.requests.memory }}"
               cpu: "{{ .Values.requests.cpu }}"
           env:
+            - name: "SERVER_PORT"
+              value: "{{ .Values.deployment.serverPort }}"
+            - name: "SERVER_SSL_ENABLED"
+              value: "{{ .Values.deployment.serverSslEnabled }}"
+            - name: "SECURITY_JWS_ENABLE"
+              value: "{{ .Values.deployment.securityJwsEnable }}"
             - name: "SPRING_PROFILES_ACTIVE"
               value: "{{ .Values.global.SPRING_PROFILES_ACTIVE }}"
             - name: "CAMEL_DISABLE-SSL"

--- a/helm/ph-ee-engine/connector-bulk/values.yaml
+++ b/helm/ph-ee-engine/connector-bulk/values.yaml
@@ -71,3 +71,6 @@ deployment:
   apiVersion: "apps/v1"
   annotations:
     deployTime: "{{ .Values.deployTime }}"
+  serverPort: "8443"
+  serverSslEnabled: true
+  securityJwsEnable: true

--- a/helm/ph-ee-engine/values.yaml
+++ b/helm/ph-ee-engine/values.yaml
@@ -1656,6 +1656,9 @@ connector_bulk:
       requests:
         memory: "512M"
         cpu: "100m"
+    serverPort: "8443"
+    serverSslEnabled: true
+    securityJwsEnable: true
 # Allows you to add any config files in /usr/share/
     # such as ph-ee-connector-bulk.yml for deployment  
     # ph-ee-connector-bulkConfig: {}


### PR DESCRIPTION


## Description

This changes allows turn on and off TLS connection with connector-bulk. 
Reason is next. GovStack is adapting Mifos. GovStack sandbox design for demo purpose. Implementing internal TLS connection between building blocks isn't necessary.

https://govstack-global.atlassian.net/browse/SND-675

## Checklist

Please make sure these boxes are checked before submitting your pull request - thanks!
- [ ] Followed the PR title naming convention mentioned above.

- [ ] Design related bullet points or design document link related to this PR added in the description above. 

- [ ] Updated corresponding Postman Collection or Api documentation for the changes in this PR.

- [ ] Created/updated unit or integration tests for verifying the changes made.

- [ ] Added required Swagger annotation and update API documentation with details of any API changes if applicable

- [ ] Followed the naming conventions as given in https://docs.google.com/document/d/1Q4vaMSzrTxxh9TS0RILuNkSkYCxotuYk1Xe0CMIkkCU/edit?usp=sharing
